### PR TITLE
add tip on layout settings before migration

### DIFF
--- a/docs/releases/updating_ez_platform.md
+++ b/docs/releases/updating_ez_platform.md
@@ -380,6 +380,16 @@ Some versions require updates to the database. Look through [the list of databas
     2. Add the bundle to `app/AppKernel.php`: `new EzSystems\EzPlatformPageMigrationBundle\EzPlatformPageMigrationBundle(),`
     3. Run command `bin/console ezplatform:page:migrate`
 
+    !!! tip
+    
+        Be aware that this script will be using de layout defined in your landing page. So if a specific
+        layout has been defined in a yml file it has been set in the ez_systems_landing_page_field_type config
+        setting. This layout settings will have to be set under ezplatform_page_fieldtype setting. 
+        If you do not do so the script will use defaut layout and your specific zones won't be used and the 
+        script will throw an exception becase it won't find your specific layout zone definitions.
+        
+    !!! tip
+        
     You can remove the bundle after the migration is complete.
 
     The command will migrate Landing Pages created in eZ Platform 1.x, 2.0 and 2.1 to new Pages.


### PR DESCRIPTION
If the specific landing page layout is not set in the page builder layout settings then the default layout will be the only one loaded and the migrating specific layout zones won't be found and an exception will be thrown.

| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->

<!-- Replace this comment with Pull Request description -->
